### PR TITLE
modify signout button to prevent weird firebaseKey issue

### DIFF
--- a/components/NavBarAuth.js
+++ b/components/NavBarAuth.js
@@ -11,8 +11,8 @@ export default function NavBarAuth() {
   const router = useRouter();
 
   const handleSignOut = () => {
-    signOut();
     router.push('/');
+    signOut();
   };
 
   return (


### PR DESCRIPTION


## Description
modified the order of routing to home and signout.  Routing first and signout after to prevent user data from not being available in the profile component before switching to home



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)